### PR TITLE
Improve performance avoiding unnecessary vos dumps

### DIFF
--- a/lib/AFS/CellCC/Check.pm
+++ b/lib/AFS/CellCC/Check.pm
@@ -56,6 +56,7 @@ _retry_state($$) {
     my ($job, $old_state) = @_;
 
     my %table = (
+        EXAM_WORK => 'EXAM_START',
         DUMP_WORK => 'DUMP_START',
         XFER_WORK => 'XFER_START',
         RESTORE_WORK => 'RESTORE_START',

--- a/lib/AFS/CellCC/Restore.pm
+++ b/lib/AFS/CellCC/Restore.pm
@@ -97,9 +97,6 @@ _checksum_valid($$$) {
     my ($job, $path, $state) = @_;
     my $fh;
 
-    my $jobid = $job->{jobid};
-    my $dvref = \$job->{dv};
-
     my ($algo, undef) = split(/:/, $job->{dump_checksum});
 
     if (!open($fh, '<', $path)) {
@@ -115,7 +112,7 @@ _checksum_valid($$$) {
 
     DEBUG "filesize valid (path $path): ".$sb->size;
 
-    my $checksum = calc_checksum($fh, $sb->size, $algo, $jobid, $dvref, $state);
+    my $checksum = calc_checksum([$job], $fh, $sb->size, $algo, $state);
     close($fh);
 
     if ($checksum ne $job->{dump_checksum}) {
@@ -230,7 +227,7 @@ _do_xfer($$) {
     # First, we have to get the actual file from the dump host to the restore
     # host, unless the db says we already have it on the restore host.
     if (!$job->{restore_filename}) {
-        if (!scratch_ok($job, $start_state, $job->{dump_filesize},
+        if (!scratch_ok([$job], $start_state, $job->{dump_filesize},
                         config_get('restore/scratch-dir'),
                         config_get('restore/scratch-minfree'))) {
             return;


### PR DESCRIPTION
Currently, every single job is completely independent of each other. As
a result, when a volume is being synchronized between several destination
cells, the same volume is dumped multiple times. In order to improve the
performance, this patch introduces a set of changes aiming to avoid
unnecessary time consuming dumps. To make it possible, the jobs
requesting the same volume with the same timestamp are grouped into a
hash table and only one dump file is generated per entry. The dump file
for a specific entry is assigned to the first job of the list and the
remaining jobs receive a copy of the file in question.