### PR TITLE
Relax --delete requirements through a new option

### DIFF
--- a/doc/pod1/cellcc_start-sync.pod
+++ b/doc/pod1/cellcc_start-sync.pod
@@ -4,7 +4,7 @@ cellcc_start-sync - Start a volume sync from one AFS cell to another
 
 =head1 SYNOPSIS
 
-B<cellcc start-sync> [B<--queue> <I<qname>>] [B<--delete>] <I<src_cell>>
+B<cellcc start-sync> [B<--queue> <I<qname>>] [B<--delete>] [B<--force-delete>] <I<src_cell>>
     <I<volume_name>>
 
 =head1 DESCRIPTION
@@ -45,6 +45,11 @@ volume in all destination cells, instead of trying to sync data.
 It is intended to run this command after the volume has been deleted in the
 source cell. B<cellcc start-sync> checks first if the volume still exists in
 the source cell, and throws an error if the volume still exists.
+
+=item B<--force-delete>
+
+Same as B<--delete> but B<cellcc start-sync> does not check if the volume
+still exists in the source cell.
 
 =back
 

--- a/lib/AFS/CellCC.pm
+++ b/lib/AFS/CellCC.pm
@@ -50,7 +50,7 @@ _exclude_volume($$$$$) {
     }
 
     my $operation = 'sync';
-    if ($opts->{delete}) {
+    if ($opts->{delete} || $opts->{forcedelete}) {
         $operation = 'delete';
     }
 
@@ -126,8 +126,8 @@ startsync($$$;$) {
         $opts = {};
     }
 
-    if ($opts->{delete}) {
-        if (volume_exists($volname, $src_cell)) {
+    if ($opts->{delete} || $opts->{forcedelete}) {
+        if (!$opts->{forcedelete} && volume_exists($volname, $src_cell)) {
             die("Error: Volume $volname still exists in cell $src_cell\n");
         }
         $start_state = 'DELETE_NEW';

--- a/lib/AFS/CellCC/CLI/cellcc.pm
+++ b/lib/AFS/CellCC/CLI/cellcc.pm
@@ -46,9 +46,11 @@ cmd_startsync($) {
     my ($argv) = @_;
     my $qname;
     my $delete = 0;
+    my $forcedelete = 0;
 
     GetOptionsFromArray($argv, 'queue=s' => \$qname,
-                               'delete' => \$delete) or parse_error();
+                               'delete' => \$delete,
+                               'force-delete' => \$forcedelete) or parse_error();
 
     if (@$argv != 2) {
         die('usage');
@@ -56,7 +58,8 @@ cmd_startsync($) {
 
     my ($src_cell, $volname) = @$argv;
 
-    my @jobs = AFS::CellCC::startsync($qname, $src_cell, $volname, {delete => $delete});
+    my @jobs = AFS::CellCC::startsync($qname, $src_cell, $volname, {delete => $delete,
+                                                                    forcedelete => $forcedelete});
     for my $job (@jobs) {
         print "[jobid $job->{jobid}]: volume $volname, cell $src_cell -> $job->{cell}\n";
     }
@@ -311,7 +314,7 @@ main($$) {
 
         'start-sync' => { func => \&cmd_startsync,
                           admin => 1,
-                          usage => "[--queue <qname>] [--delete] <src_cell> <volume_name>",
+                          usage => "[--queue <qname>] [--delete] [--force-delete] <src_cell> <volume_name>",
                         },
 
         'dump-server' => { func => \&cmd_dumpserver,


### PR DESCRIPTION
The original cellcc start-sync --delete flag is used to delete the
specified volume in all destination cells. This option only works if
the volume in question was already removed from the source cell.
Unfortunately, this is not always desirable.

This commit introduces a new flag called --forcedelete. This option
deletes the specified volume in all destination cells even if this
volume still exists in the source cell.