### PR TITLE
Do not fail if status of target volume is ok

### DIFF
--- a/lib/AFS/CellCC/VOS.pm
+++ b/lib/AFS/CellCC/VOS.pm
@@ -239,17 +239,18 @@ find_volume(%) {
             die("Error: vldb entry ".$entry->name." is locked; volume may not be stable");
         }
         for my $site ($entry->getVLDBSites()) {
-            if ($site->status) {
-                die("Error: vldb entry ".$entry->name." site has status '".$site->status."'; ".
-                    "volume may not be stable\n");
-            }
             DEBUG "vlentry ".$entry->name." site ".$site->type." ".$site->server." ".$site->partition;
             if ($site->type eq $args{type}) {
                 if ($args{server} && !_site_eq($site->server, $args{server})) {
                     next;
                 }
+                if ($site->status and $site->status ne "New release") {
+                    die("Error: vldb entry ".$entry->name." site has status '"
+                        .$site->status."'; "."volume may not be stable\n");
+                }
                 $server = $site->server;
                 $partition = $site->partition;
+                last;
             }
         }
     }


### PR DESCRIPTION
Currently, CellCC does not dump / restore a volume if the status of this
volume (in at least one server) is equal to one of the following values:
‘New release’, ‘Old release’, or ‘Not released’. Fortunately, this
conservative approach is not really necessary. First of all, the only
status that should be taken into consideration is the status from the
server where the volume is going to be dumped / restored. Secondly, if
the status of this volume (on this server) is equal to ‘New release’,
this means that this server has the most recent version of the volume
and we should be able to proceed.

To fix this problem, only take into consideration the status of the
volume from the target server. If this status indicates we have the most
recent version, proceed.