### PR TITLE
Do not release empty volume before restoration

### DIFF
--- a/lib/AFS/CellCC/Restore.pm
+++ b/lib/AFS/CellCC/Restore.pm
@@ -333,11 +333,6 @@ _create_volume($$) {
             or die("vos addsite error: ".$vos->errors());
     }
 
-    if (@sites) {
-        $vos->release(id => $job->{volname}, cell => $job->{dst_cell})
-            or die("vos release error: ".$vos->errors());
-    }
-
     $vos->offline(id => $job->{volname},
                   server => $rwserver,
                   partition => $rwpartition,


### PR DESCRIPTION
Currently, the restore daemon checks if the volume received from the
dump server is present in its local cell. If not, the following actions
will be performed by this process:

1. An empty volume with the same name will be created;
2. The replicas will be added;
3. The empty volume will be released;

At this point, the dump file received from the dump server is restored
on top of this empty volume. After that, the volume in question is
released.

Unfortunately, this current approach can be problematic. As one can
imagine, the update time of the empty volume is gonna be newer than the
update time of the volume being restored. As a result, the incremental
release of the latter will not update the replicas correctly.

To fix this problem, do not release the empty volume created during the
RESTORE_WORK state when the volume in question does not exist in the
destination cell.