### PR TITLE
Check and reap already-dead children frequently

### DIFF
--- a/lib/AFS/CellCC.pm
+++ b/lib/AFS/CellCC.pm
@@ -211,6 +211,10 @@ dumpserver($$$;$) {
 
         my $seconds = config_get('dump/check-interval');
         sleep($seconds);
+
+        # Reap any finished children now, in case it takes a long time for us
+        # to call $pm->start() again.
+        $pm->reap_finished_children();
     }
 
     $pm->wait_all_children();

--- a/lib/AFS/CellCC/Restore.pm
+++ b/lib/AFS/CellCC/Restore.pm
@@ -690,6 +690,10 @@ server($$;$) {
 
         my $seconds = config_get('restore/check-interval');
         sleep($seconds);
+
+        # Reap any finished children now, in case it takes a long time for us
+        # to call $pm->start() again.
+        $pm->reap_finished_children();
     }
 
     $pm->wait_all_children();


### PR DESCRIPTION
Currently, CellCC uses a parallel processing fork manager called
Parallel::ForkManager. With this module, already-dead children are
reaped by the same function used to fork new processes. As a result,
processes that have completed execution will not be removed from the
process table until the next fork. Knowing that zombies that exist for
more than a short period of time typically indicate that something is
wrong, the code introduced by this commit reaps already-dead children
every "check-interval" seconds.