### PR TITLE
Allow extra arguments for vos release

### DIFF
--- a/doc/pod1/cellcc_config.pod
+++ b/doc/pod1/cellcc_config.pod
@@ -449,6 +449,26 @@ This indicates how many restores the restore-server will perform in parallel
 for volume sync jobs in the queue named by <I<qname>>. An explanation of queues
 can be found in the manpage for L<cellcc_start-sync(1)>.
 
+=item B<restore/queues/><I<qname>>B<release/flags>
+
+This can be used to pass extra options to the "vos release" command line when
+CellCC releases a volume. These options are specific to the queue named by
+<I<qname>> and must be given as an associative array as accepted by
+AFS::Command, with the option name as the key and its argument as the value. For
+example, to pass "-encrypt", specify the following:
+
+  restore: {
+    queues: {
+      <qname>: {
+        release: {
+          flags: {
+            encrypt: 1,
+          },
+        },
+      },
+    },
+  },
+
 =item B<xfer/monitor-intervals>
 
 This is the same as B<dump/monitor-intervals>, but is for the restore-server

--- a/doc/pod1/cellcc_config.pod
+++ b/doc/pod1/cellcc_config.pod
@@ -443,13 +443,13 @@ of the dump-server. See B<dump/scratch-minfree>.
 This is identical to B<dump/check-interval>, but for the restore-server instead
 of the dump-server.
 
-=item B<restore/queues/><I<qname>>B<max-parallel>
+=item B<restore/queues/><I<qname>>B</max-parallel>
 
 This indicates how many restores the restore-server will perform in parallel
 for volume sync jobs in the queue named by <I<qname>>. An explanation of queues
 can be found in the manpage for L<cellcc_start-sync(1)>.
 
-=item B<restore/queues/><I<qname>>B<release/flags>
+=item B<restore/queues/><I<qname>>B</release/flags>
 
 This can be used to pass extra options to the "vos release" command line when
 CellCC releases a volume. These options are specific to the queue named by

--- a/lib/AFS/CellCC/Config.pm
+++ b/lib/AFS/CellCC/Config.pm
@@ -107,6 +107,8 @@ my @directives = (
     { key => 'restore/check-interval', default => 60, },
     { key => 'restore/queues', type => 'HASH', default => {}, },
     { key => qr:^restore/queues/[^/]+/max-parallel$:, default => 1, },
+    { key => qr:^restore/queues/[^/]+/release/flags$:, type => 'HASH', default => {}, },
+    { key => qr:^restore/queues/[^/]+/release/flags/[^/]+$:, },
 
     { key => 'xfer/monitor-intervals', default => $_default_check_intervals,
       type => 'ARRAY', },

--- a/lib/AFS/CellCC/Restore.pm
+++ b/lib/AFS/CellCC/Restore.pm
@@ -471,10 +471,18 @@ _do_release($$) {
     my $pid = spawn_child(name => 'vos release handler',
                           stderr => $stderr_fh->filename,
                           cb => sub {
+        my %args;
+        my %flags = %{ config_get("restore/queues/$job->{qname}/release/flags") };
         my $vos = vos_auth();
-        $vos->release(id => $job->{volname},
-                      cell => $job->{dst_cell})
-        or die("vos release error: ".$vos->errors());
+
+        $args{id} = $job->{volname};
+        $args{cell} = $job->{dst_cell};
+
+        while (my ($key, $value) = each %flags) {
+            $args{$key} = $value;
+        }
+
+        $vos->release(%args) or die("vos release error: ".$vos->errors());
     });
 
     monitor_child($pid, { name => 'vos release handler',


### PR DESCRIPTION
The commands in the vos command suite are the administrative interface
to the Volume Server and Volume Location Server. As we know, CellCC
takes advantage of these commands to synchronize volumes between AFS
cells. Unfortunately, the system administrator does not have the freedom
to specify which options will be passed to vos.

To mitigate the limitation mentioned above, accept extra arguments for
vos release. To make it possible, read the cellcc.json configuration
file to check if any extra flag was provided by the user.